### PR TITLE
Fix repeated dbResets so tests run faster

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -1,10 +1,6 @@
 // default app configuration
 const port = process.env.PORT || 4000;
-let db = process.env.MONGOLAB_URI || process.env.MONGODB_URI;
-
-if (!db) {
-    db = 'mongodb://localhost:27017/nodegoat';
-}
+let db = process.env.MONGODB_URI || "mongodb://localhost:27017/nodegoat";
 
 module.exports = {
     port,

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -3,7 +3,7 @@ const port = process.env.PORT || 4000;
 let db = process.env.MONGOLAB_URI || process.env.MONGODB_URI;
 
 if (!db) {
-    db = process.env.NODE_ENV === 'test' ? 'mongodb://localhost:27017/nodegoat' : 'mongodb://nodegoat:owasp@nodegoat-cluster-shard-00-00.zkkl5.mongodb.net:27017,nodegoat-cluster-shard-00-01.zkkl5.mongodb.net:27017,nodegoat-cluster-shard-00-02.zkkl5.mongodb.net:27017/nodegoat?ssl=true&replicaSet=atlas-qajmlr-shard-0&authSource=admin&retryWrites=true&w=majority';
+    db = 'mongodb://localhost:27017/nodegoat';
 }
 
 module.exports = {

--- a/test/e2e/integration/allocations_spec.js
+++ b/test/e2e/integration/allocations_spec.js
@@ -5,10 +5,6 @@ describe('/allocations behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/benefits_spec.js
+++ b/test/e2e/integration/benefits_spec.js
@@ -5,10 +5,6 @@ describe('/login behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/contributions_spec.js
+++ b/test/e2e/integration/contributions_spec.js
@@ -5,10 +5,6 @@ describe('/contributions behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/login_spec.js
+++ b/test/e2e/integration/login_spec.js
@@ -5,10 +5,6 @@ describe('/login behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/logout_spec.js
+++ b/test/e2e/integration/logout_spec.js
@@ -5,10 +5,6 @@ describe('/logout behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   it('Should redirect if the user has not logged in', () => {
     cy.visitPage('/logout')
     cy.url().should('include', 'login')

--- a/test/e2e/integration/memos_spec.js
+++ b/test/e2e/integration/memos_spec.js
@@ -5,10 +5,6 @@ describe('/memos behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/profile_spec.js
+++ b/test/e2e/integration/profile_spec.js
@@ -5,10 +5,6 @@ describe('/profile behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/integration/signup_spec.js
+++ b/test/e2e/integration/signup_spec.js
@@ -5,10 +5,6 @@ describe('/signup behaviour', () => {
     cy.dbReset()
   })
 
-  after(() => {
-    cy.dbReset()
-  })
-
   afterEach(() => {
     cy.visitPage('/logout')
   })

--- a/test/e2e/plugins/index.js
+++ b/test/e2e/plugins/index.js
@@ -8,10 +8,16 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
+const { port, hostName } = require('../../../config/env/all')
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+
+  config.baseUrl = `http://${hostName}:${port}`
+
+  return config
 }

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -1,7 +1,5 @@
-const { port, hostName } = require('../../../config/env/all')
-
 Cypress.Commands.add('signIn', (usr, pw) => {
-  cy.visit(`http://${hostName}:${port}/login`)
+  cy.visitPage('/login')
   cy.get('#userName').type(usr)
   cy.get('#password').type(pw)
   cy.get('[type="submit"]').click()
@@ -22,7 +20,7 @@ Cypress.Commands.add('userSignIn', () => {
 })
 
 Cypress.Commands.add('visitPage', (path = '/', config = {}) => {
-  cy.visit(`http://${hostName}:${port}${path}`, config)
+  cy.visit(path, config)
 })
 
 Cypress.Commands.add('dbReset', () => {


### PR DESCRIPTION
* Set config.baseUrl and visit relative URLs to avoid Cypress bug which
  runs "before" hooks twice (github.com/cypress-io/cypress/issues/2777)
* Remove "after" hook dbResets; make tests responsible for their own
  initial state, not that of the subsequent test